### PR TITLE
benchmark: Make the latency benchmark resoultion to ns

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -150,7 +150,7 @@ void benchmark_latency(int iterations) {
             tee.flush_thread_buffer();
             
             auto end = std::chrono::high_resolution_clock::now();
-            auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+            auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
             latencies.push_back(duration);
         }
         
@@ -162,10 +162,10 @@ void benchmark_latency(int iterations) {
         double p99 = latencies[static_cast<size_t>(latencies.size() * 0.99)];
         
         std::cout << "Size: " << std::setw(8) << size << " bytes | "
-                  << "Avg: " << std::setw(8) << std::fixed << std::setprecision(2) << avg << " µs | "
-                  << "Median: " << std::setw(8) << median << " µs | "
-                  << "p95: " << std::setw(8) << p95 << " µs | "
-                  << "p99: " << std::setw(8) << p99 << " µs" << std::endl;
+                  << "Avg: " << std::setw(8) << std::fixed << std::setprecision(2) << avg << " ns | "
+                  << "Median: " << std::setw(8) << median << " ns | "
+                  << "p95: " << std::setw(8) << p95 << " ns | "
+                  << "p99: " << std::setw(8) << p99 << " ns" << std::endl;
     }
     
     std::cout << "\nNaive implementation latency:" << std::endl;
@@ -184,7 +184,7 @@ void benchmark_latency(int iterations) {
             null_stream2.flush();
             
             auto end = std::chrono::high_resolution_clock::now();
-            auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+            auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
             latencies.push_back(duration);
         }
         
@@ -196,10 +196,10 @@ void benchmark_latency(int iterations) {
         double p99 = latencies[static_cast<size_t>(latencies.size() * 0.99)];
         
         std::cout << "Size: " << std::setw(8) << size << " bytes | "
-                  << "Avg: " << std::setw(8) << std::fixed << std::setprecision(2) << avg << " µs | "
-                  << "Median: " << std::setw(8) << median << " µs | "
-                  << "p95: " << std::setw(8) << p95 << " µs | "
-                  << "p99: " << std::setw(8) << p99 << " µs" << std::endl;
+                  << "Avg: " << std::setw(8) << std::fixed << std::setprecision(2) << avg << " ns | "
+                  << "Median: " << std::setw(8) << median << " ns | "
+                  << "p95: " << std::setw(8) << p95 << " ns | "
+                  << "p99: " << std::setw(8) << p99 << " ns" << std::endl;
     }
 }
 

--- a/tests/test_teestream.cpp
+++ b/tests/test_teestream.cpp
@@ -117,8 +117,8 @@ TEST(TeeStreamTest, MultithreadedAccess) {
     tee.add_stream(stream1);
     tee.add_stream(stream2);
     
-    const int num_threads = 4;  // Reduced from 10 to reduce contention
-    const int iterations = 50;  // Reduced from 100
+    const int num_threads = 10;
+    const int iterations = 100;
     
     std::mutex output_mutex;  // Add mutex for synchronizing output
     
@@ -127,9 +127,6 @@ TEST(TeeStreamTest, MultithreadedAccess) {
             // Use the mutex to synchronize access to the tee stream
             std::lock_guard<std::mutex> lock(output_mutex);
             tee << "Thread " << thread_id << " iteration " << i << std::endl;
-            
-            // Add a small sleep to reduce contention
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     };
     


### PR DESCRIPTION
- TeeStreamTest::MultithreadedAccess : Bump back the number of threads and interations. Remove the call to sleep the thread